### PR TITLE
更新一键评教工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@
 
 #### 一键评教
 
-- [GitHub - bearbattle/buaa-teacher-evaluation: 北航教务一键评教。](https://github.com/bearbattle/buaa-teacher-evaluation)【PYTHON】
+- ~~[GitHub - bearbattle/buaa-teacher-evaluation: 北航教务一键评教。](https://github.com/bearbattle/buaa-teacher-evaluation)【PYTHON】~~
 
-- [GitHub - APassbyDreg/BUAA_JW_Utils: 北航教务辅助脚本工具集](https://github.com/APassbyDreg/BUAA_JW_Utils)【SELENIUM】
+- ~~[GitHub - APassbyDreg/BUAA_JW_Utils: 北航教务辅助脚本工具集](https://github.com/APassbyDreg/BUAA_JW_Utils)【SELENIUM】~~
+
+- [GitHub - el-ev/BUAA-Teacher-Evaluation：北航教务一键评教](https://github.com/el-ev/BUAA-Teacher-Evaluation)【PYTHON】
+
+- [GitHub - ZenAlexa/BUAA_TeachingEvaluation_2024Winter：BUAA一键多方式综合评教](https://github.com/ZenAlexa/BUAA_TeachingEvaluation_2024Winter)【PYTHON】
 
 #### 查询成绩
 


### PR DESCRIPTION
2024 年北航更新了评教系统（<https://spoc.buaa.edu.cn/pjxt/>），之前的一键评教工具全部失效。

我划去了所有之前的一键评教工具，并添加了两个我所知道的新工具。